### PR TITLE
added .cassius support closes #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
-## 0.0.0 - First Release
+## 0.0.0 — First Release
 * Added basic support for the three Shakespearean interpolations in lucius, julius and hamlet
 * BUG: some interpolations are still not highlighted when present in strings or other contexts
+## 0.1.1 — added .cassius
+* added support for .cassius files

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Shakespeare Templates support in Atom
 
-Adds syntax highlighting and snippets to .julius, .hamlet and .lucius files in Atom.
+Adds syntax highlighting and snippets to .cassius, .hamlet, .julius, and .lucius files in Atom.
 
 Contributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.

--- a/grammars/cassius.cson
+++ b/grammars/cassius.cson
@@ -1,0 +1,30 @@
+'fileTypes': [
+  'cassius'
+]
+'name': 'CSS (Cassius)'
+'patterns': [
+  {
+    'include': 'source.css'
+  }
+  {
+    'include': '#interpolated_haskell'
+  }
+]
+'repository':
+  'interpolated_haskell':
+    'patterns': [
+      {
+        'begin': '[#@^]\\{'
+        'captures':
+          '0':
+            'name': 'entity.name.tag.cassius'
+        'end': '\\}'
+        'name': 'meta.tag.template.cassius'
+        'patterns': [
+          {
+            'include': 'source.haskell'
+          }
+        ]
+      }
+    ]
+'scopeName': 'source.css.cassius'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-shakespeare",
   "version": "0.1.0",
-  "description": "Atom language support for Yesod's Shakespeare templates (hamlet, lucius, julius)",
+  "description": "Atom language support for Yesod's Shakespeare templates (cassius, hamlet, julius, lucius)",
   "repository": "https://github.com/Hudon/language-shakespeare",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-shakespeare",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Atom language support for Yesod's Shakespeare templates (cassius, hamlet, julius, lucius)",
   "repository": "https://github.com/Hudon/language-shakespeare",
   "license": "MIT",


### PR DESCRIPTION
Cassius is identical to Lucius, just without extraneous semicolons and
braces. The two files should be kept updated together, just with the
different names. Tested and working.

Fixes issue #2 