### PR TITLE
Add support for hamlet comments

### DIFF
--- a/settings/language-shakespeare.cson
+++ b/settings/language-shakespeare.cson
@@ -1,0 +1,3 @@
+'.text.html.hamlet':
+  'editor':
+    'commentStart': '$# '


### PR DESCRIPTION
This commit enables the hamlet comment notation (`$# `) to be used in templates.